### PR TITLE
Make the output reproducible.

### DIFF
--- a/stardicter/base.py
+++ b/stardicter/base.py
@@ -30,6 +30,7 @@ from operator import attrgetter
 import os
 import re
 import struct
+import time
 
 from six.moves.urllib.request import urlopen
 from six import BytesIO
@@ -386,7 +387,9 @@ class StardictWriter(object):
             handle.write(self.convert('website={0}\n'.format(URL), False))
             # we're using pango markup for all entries
             handle.write('sametypesequence=g\n')
-            handle.write(datetime.date.today().strftime('date=%Y.%m.%d\n'))
+            now = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+            today = datetime.datetime.utcfromtimestamp(now)
+            handle.write(today.strftime('date=%Y.%m.%d\n'))
 
     def write_dict(self, directory):
         '''


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that stardicter generates non-deterministic output in .ifo files.

In particular, it adds the current date and time.

Patch attached that uses SOURCE_DATE_EPOCH[1] if available.

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/